### PR TITLE
Update yocto.md

### DIFF
--- a/etc/internal/yocto.md
+++ b/etc/internal/yocto.md
@@ -39,5 +39,5 @@ sudo ./uuu-native/bin/uuu -v -b emmc ./imx-boot
 
 * Flash the bootloader and the OS image onto the emmc:
 ```
-sudo ./uuu-native/bin/uuu -v -b emmc_all ./imx-boot ./${TARGET-IMAGE}-${MACHINE}.tar.bz2
+sudo ./uuu-native/bin/uuu -v -b emmc_all ./imx-boot ./${TARGET-IMAGE}-${MACHINE}.wic.bz2
 ```


### PR DESCRIPTION
Update uuu flashing command to use WIC image

Using the tar image does not write the partitions and fails to boot. After updating this to use the wic file from the yocto output, I was able to boot successfully